### PR TITLE
Integrate Power API into Quebec and PEI Parsers

### DIFF
--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -10,58 +10,7 @@ import arrow
 from requests import Session
 
 timezone = "Canada/Atlantic"
-
-
-def _find_pei_key(pei_list, sought_key):
-    matching_item = [
-        item
-        for item in pei_list
-        if "header" in item["data"] and item["data"]["header"].startswith(sought_key)
-    ]
-
-    if not matching_item:
-        return None
-
-    return matching_item[0]["data"]["actualValue"]
-
-
-def _get_pei_info(requests_obj):
-    url = "https://wdf.princeedwardisland.ca/api/workflow"
-    request = {"featureName": "WindEnergy", "queryName": "WindEnergy"}
-    headers = {"Content-Type": "application/json"}
-    response = requests_obj.post(url, data=json.dumps(request), headers=headers)
-
-    raw_data = response.json().get("data") or []
-
-    datetime_item = [
-        item["data"]["text"] for item in raw_data if "text" in item["data"]
-    ]
-    if not datetime_item:
-        # unable to get a timestamp, return empty
-        return None
-    datetime_text = datetime_item[0][len("Last updated ") :]
-    data_timestamp = arrow.get(datetime_text, "MMMM D, YYYY HH:mm A").replace(
-        tzinfo="Canada/Atlantic"
-    )
-
-    # see https://ruk.ca/content/new-api-endpoint-pei-wind for more info
-    data = {
-        "pei_load": _find_pei_key(raw_data, "Total On-Island Load"),
-        "pei_wind_gen": _find_pei_key(raw_data, "Total On-Island Wind Generation"),
-        "pei_fossil_gen": _find_pei_key(
-            raw_data, "Total On-Island Fossil Fuel Generation"
-        ),
-        "pei_wind_used": _find_pei_key(raw_data, "Wind Power Used On Island"),
-        "pei_wind_exported": _find_pei_key(raw_data, "Wind Power Exported Off Island"),
-        "datetime": data_timestamp.datetime,
-    }
-
-    # the following keys are always required downstream, if we don't have them, no sense returning
-    if data["pei_wind_gen"] is None or data["pei_fossil_gen"] is None:
-        return None
-
-    return data
-
+URL = "localhost:8000/province/PE"
 
 def fetch_production(
     zone_key: str = "CA-PE",
@@ -73,8 +22,8 @@ def fetch_production(
     if target_datetime:
         raise NotImplementedError("This parser is not yet able to parse past dates")
 
-    requests_obj = session or Session()
-    pei_info = _get_pei_info(requests_obj)
+    session = session or Session()
+    pei_info = session.get(f"{URL}/production").json()
 
     if pei_info is None:
         return None
@@ -82,18 +31,7 @@ def fetch_production(
     data = {
         "datetime": pei_info["datetime"],
         "zoneKey": zone_key,
-        "production": {
-            "wind": pei_info["pei_wind_gen"],
-            # These are oil-fueled ("heavy fuel oil" and "diesel") generators
-            # used as peakers and back-up
-            "oil": pei_info["pei_fossil_gen"],
-            # specify some sources that definitely aren't present on PEI as zero,
-            # this allows the analyzer to better estimate CO2eq
-            "coal": 0,
-            "hydro": 0,
-            "nuclear": 0,
-            "geothermal": 0,
-        },
+        "production": pei_info["production"],
         "storage": {},
         "source": "princeedwardisland.ca",
     }
@@ -117,28 +55,11 @@ def fetch_exchange(
     if sorted_zone_keys != "CA-NB->CA-PE":
         raise NotImplementedError("This exchange pair is not implemented")
 
-    requests_obj = session or Session()
-    pei_info = _get_pei_info(requests_obj)
+    session = session or Session()
+    pei_info = session.get(f"{URL}/exchange").json()
 
-    if pei_info is None or pei_info["pei_load"] is None:
+    if pei_info is None:
         return None
-
-    # PEI imports most of its electricity. Everything not generated on island
-    # is imported from New Brunswick.
-    # In case of wind, some is paper-"exported" even if there is a net import,
-    # and 'pei_wind_used'/'data5' indicates their accounting of part of the load
-    # served by non-exported wind.
-    # https://www.princeedwardisland.ca/en/feature/pei-wind-energy says:
-    # "Wind Power Exported Off-Island is that portion of wind generation that is supplying
-    # contracts elsewhere. The actual electricity from this portion of wind generation
-    # may stay within PEI but is satisfying a contractual arrangement in another jurisdiction."
-    # We are ignoring these paper exports, as they are an accounting/legal detail
-    # that doesn't actually reflect what happens on the wires.
-    # (New Brunswick being the only interconnection with PEI, "exporting" wind power to NB
-    # then "importing" a balance of NB electricity likely doesn't actually happen.)
-    imported_from_nb = (
-        pei_info["pei_load"] - pei_info["pei_fossil_gen"] - pei_info["pei_wind_gen"]
-    )
 
     # In expected result, "net" represents an export.
     # We have sorted_zone_keys 'CA-NB->CA-PE', so it's export *from* NB,
@@ -146,7 +67,7 @@ def fetch_exchange(
     data = {
         "datetime": pei_info["datetime"],
         "sortedZoneKeys": sorted_zone_keys,
-        "netFlow": imported_from_nb,
+        "netFlow": pei_info["flow"]["New Brunswick"],
         "source": "princeedwardisland.ca",
     }
 

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -10,7 +10,9 @@ import arrow
 from requests import Session
 
 timezone = "Canada/Atlantic"
+
 URL = "localhost:8000/province/PE"
+
 
 def fetch_production(
     zone_key: str = "CA-PE",

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -9,9 +9,9 @@ from typing import Any, Dict, Optional
 import arrow
 from requests import Session
 
-timezone = "Canada/Atlantic"
+TIMEZONE = "Canada/Atlantic"
 
-URL = "localhost:8000/province/PE"
+URL = "http://localhost:8000/province/PE"
 
 
 def fetch_production(
@@ -31,7 +31,7 @@ def fetch_production(
         return None
 
     data = {
-        "datetime": pei_info["datetime"],
+        "datetime": get_current_timestamp(),
         "zoneKey": zone_key,
         "production": pei_info["production"],
         "storage": {},
@@ -67,13 +67,17 @@ def fetch_exchange(
     # We have sorted_zone_keys 'CA-NB->CA-PE', so it's export *from* NB,
     # and import *to* PEI.
     data = {
-        "datetime": pei_info["datetime"],
+        "datetime": get_current_timestamp(),
         "sortedZoneKeys": sorted_zone_keys,
         "netFlow": pei_info["flow"]["New Brunswick"],
         "source": "princeedwardisland.ca",
     }
 
     return data
+
+
+def get_current_timestamp():
+    return arrow.utcnow().to(TIMEZONE).datetime
 
 
 if __name__ == "__main__":

--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -9,6 +9,7 @@ from requests import Session
 
 PRODUCTION_URL = "localhost:8000/province/QC/production"
 CONSUMPTION_URL = "https://www.hydroquebec.com/data/documents-donnees/donnees-ouvertes/json/demande.json"
+
 # Reluctant to call it 'timezone', since we are importing 'timezone' from datetime
 timezone_id = "America/Montreal"
 

--- a/parsers/CA_QC.py
+++ b/parsers/CA_QC.py
@@ -7,11 +7,11 @@ from typing import Optional
 import arrow
 from requests import Session
 
-PRODUCTION_URL = "localhost:8000/province/QC/production"
+PRODUCTION_URL = "http://localhost:8000/province/QC/production"
 CONSUMPTION_URL = "https://www.hydroquebec.com/data/documents-donnees/donnees-ouvertes/json/demande.json"
 
 # Reluctant to call it 'timezone', since we are importing 'timezone' from datetime
-timezone_id = "America/Montreal"
+TIMEZONE = "America/Montreal"
 
 
 def fetch_production(
@@ -43,7 +43,7 @@ def fetch_production(
     data = _fetch_quebec_production(session)
     res = {
         "zoneKey": zone_key,
-        "datetime": data["datetime"],
+        "datetime": get_current_timestamp(),
         "production": data["production"],
         "source": "hydroquebec.com",
     }
@@ -63,7 +63,7 @@ def fetch_consumption(
             list_res.append(
                 {
                     "zoneKey": zone_key,
-                    "datetime": arrow.get(elem["date"], tzinfo=timezone_id).datetime,
+                    "datetime": get_current_timestamp(),
                     "consumption": elem["valeurs"]["demandeTotal"],
                     "source": "hydroquebec.com",
                 }
@@ -99,6 +99,10 @@ def _fetch_quebec_consumption(
             )
         )
     return response.json()
+
+
+def get_current_timestamp():
+    return arrow.utcnow().to(TIMEZONE).datetime
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds changes to integrate the Quebec and PEI endpoints of Power API into their respective parser. Note that the endpoint is currently `localhost:8000`.

Todo: test endpoint integration works...